### PR TITLE
2022.11.08  newer fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,4 +63,5 @@ jobs:
           pip install opencv-python==4.5.4.60
           pip install easyocr pillow numpy
           pip install -r requirements.txt
+          export OPENSSL_CONF=./openssl.cnf
           python3 ./dailyFudan.py '${{ secrets.FUDAN }}'

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation


### PR DESCRIPTION
when build our own workflow, we find a little issue at "run sign" which leads to building failure, to fix up this, we need to figure out that system tell us that when enabling Legacy Unsafe Renegotiation, SSL connections will be vulnerable to the Man-in-the-Middle prefix attack as described in [CVE-2009-3555](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CAN-2009-3555).
Beware that editing your system's openssl.conf is not recommended, because you might lose your changes once openssl is updated.
So just create a custom openssl.cnf file in any directory with these contents, such as:

**
openssl_conf = openssl_init

[openssl_init]
ssl_conf = ssl_sect

[ssl_sect]
system_default = system_default_sect

[system_default_sect]
Options = UnsafeLegacyRenegotiation
**

When you run this workflow, just 'export OPENSSL_CONF=/path/to/custom/openssl.cnf' before run yourscraper.py
Get it!